### PR TITLE
define source encoding as UTF-8 to fix build errors in Jenkins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,11 @@
     <version>0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
a little improvement for the maven build: defined the source code encoding
